### PR TITLE
Better JSON printer

### DIFF
--- a/akka-http/src/test/scala/com/avast/grpc/jsonbridge/akkahttp/AkkaHttpTest.scala
+++ b/akka-http/src/test/scala/com/avast/grpc/jsonbridge/akkahttp/AkkaHttpTest.scala
@@ -46,11 +46,7 @@ class AkkaHttpTest extends FunSuite with ScalatestRouteTest {
       .withHeaders(AkkaHttp.JsonContentType) ~> route ~> check {
       assertResult(StatusCodes.OK)(status)
 
-      assertResult("""{
-                     |  "results": {
-                     |    "name": 42
-                     |  }
-                     |}""".stripMargin)(responseAs[String])
+      assertResult("""{"results":{"name":42}}""")(responseAs[String])
 
       assertResult(Seq(`Content-Type`(ContentType.WithMissingCharset(MediaType.applicationWithOpenCharset("json")))))(headers)
     }
@@ -73,11 +69,7 @@ class AkkaHttpTest extends FunSuite with ScalatestRouteTest {
       .withHeaders(AkkaHttp.JsonContentType) ~> route ~> check {
       assertResult(StatusCodes.OK)(status)
 
-      assertResult("""{
-                     |  "results": {
-                     |    "name": 42
-                     |  }
-                     |}""".stripMargin)(responseAs[String])
+      assertResult("""{"results":{"name":42}}""")(responseAs[String])
     }
   }
 
@@ -163,11 +155,7 @@ class AkkaHttpTest extends FunSuite with ScalatestRouteTest {
       .withHeaders(AkkaHttp.JsonContentType, customHeaderToBeSent) ~> route ~> check {
       assertResult(StatusCodes.OK)(status)
 
-      assertResult("""{
-                     |  "results": {
-                     |    "name": 42
-                     |  }
-                     |}""".stripMargin)(responseAs[String])
+      assertResult("""{"results":{"name":42}}""")(responseAs[String])
 
       assertResult(Seq(`Content-Type`(ContentType.WithMissingCharset(MediaType.applicationWithOpenCharset("json")))))(headers)
     }

--- a/core/src/main/scala/com/avast/grpc/jsonbridge/GrpcJsonBridgeBase.scala
+++ b/core/src/main/scala/com/avast/grpc/jsonbridge/GrpcJsonBridgeBase.scala
@@ -16,6 +16,8 @@ import scala.util.control.NonFatal
 trait GrpcJsonBridgeBase[Stub <: io.grpc.stub.AbstractStub[Stub]] extends StrictLogging {
 
   protected def newFutureStub: Stub
+  protected val parser: JsonFormat.Parser = JsonFormat.parser()
+  protected val printer: JsonFormat.Printer = JsonFormat.printer().includingDefaultValueFields().omittingInsignificantWhitespace()
 
   // https://groups.google.com/forum/#!topic/grpc-io/1-KMubq1tuc
   protected def withNewClientStub[A](headers: Seq[GrpcHeader])(f: Stub => Future[A])(
@@ -53,7 +55,7 @@ trait GrpcJsonBridgeBase[Stub <: io.grpc.stub.AbstractStub[Stub]] extends Strict
   protected def fromJson[Gpb <: Message](inst: Gpb, json: String): Either[Status, Gpb] = {
     try {
       val builder = inst.newBuilderForType()
-      JsonFormat.parser().merge(json, builder)
+      parser.merge(json, builder)
       Right {
         builder.build().asInstanceOf[Gpb]
       }
@@ -66,6 +68,6 @@ trait GrpcJsonBridgeBase[Stub <: io.grpc.stub.AbstractStub[Stub]] extends Strict
   }
 
   protected def toJson(resp: Message): String = {
-    JsonFormat.printer().print(resp)
+    printer.print(resp)
   }
 }

--- a/core/src/test/scala/com/avast/grpc/jsonbridge/GrpcJsonBridgeTest.scala
+++ b/core/src/test/scala/com/avast/grpc/jsonbridge/GrpcJsonBridgeTest.scala
@@ -45,11 +45,7 @@ class GrpcJsonBridgeTest extends FunSuite with ScalaFutures {
       .runAsync
       .futureValue
 
-    assertResult("""{
-                   |  "results": {
-                   |    "name": 42
-                   |  }
-                   |}""".stripMargin)(response)
+    assertResult("""{"results":{"name":42}}""")(response)
 
     assertResult(Left(Status.NOT_FOUND)) {
       bridge
@@ -122,11 +118,7 @@ class GrpcJsonBridgeTest extends FunSuite with ScalaFutures {
       .runAsync
       .futureValue
 
-    assertResult("""{
-                   |  "results": {
-                   |    "name": 42
-                   |  }
-                   |}""".stripMargin)(response)
+    assertResult("""{"results":{"name":42}}""")(response)
   }
 
 }

--- a/http4s/src/test/scala/com/avast/grpc/jsonbrige/http4s/Http4sTest.scala
+++ b/http4s/src/test/scala/com/avast/grpc/jsonbrige/http4s/Http4sTest.scala
@@ -59,11 +59,7 @@ class Http4sTest extends FunSuite with ScalaFutures {
 
     assertResult(org.http4s.Status.Ok)(response.status)
 
-    assertResult("""{
-                   |  "results": {
-                   |    "name": 42
-                   |  }
-                   |}""".stripMargin)(response.as[String].unsafeRunSync())
+    assertResult("""{"results":{"name":42}}""")(response.as[String].unsafeRunSync())
 
     assertResult(
       Headers(
@@ -99,11 +95,7 @@ class Http4sTest extends FunSuite with ScalaFutures {
 
     assertResult(org.http4s.Status.Ok)(response.status)
 
-    assertResult("""{
-                   |  "results": {
-                   |    "name": 42
-                   |  }
-                   |}""".stripMargin)(response.as[String].unsafeRunSync())
+    assertResult("""{"results":{"name":42}}""")(response.as[String].unsafeRunSync())
 
     assertResult(
       Headers(

--- a/http4s/src/test/scala/com/avast/grpc/jsonbrige/http4s/Http4sTest.scala
+++ b/http4s/src/test/scala/com/avast/grpc/jsonbrige/http4s/Http4sTest.scala
@@ -64,7 +64,7 @@ class Http4sTest extends FunSuite with ScalaFutures {
     assertResult(
       Headers(
         `Content-Type`(MediaType.`application/json`),
-        `Content-Length`.fromLong(37).getOrElse(fail())
+        `Content-Length`.fromLong(23).getOrElse(fail())
       ))(response.headers)
 
   }
@@ -100,7 +100,7 @@ class Http4sTest extends FunSuite with ScalaFutures {
     assertResult(
       Headers(
         `Content-Type`(MediaType.`application/json`),
-        `Content-Length`.fromLong(37).getOrElse(fail())
+        `Content-Length`.fromLong(23).getOrElse(fail())
       ))(response.headers)
 
   }


### PR DESCRIPTION
1. The default values should be printed IMHO. E.g. if you have an enum and the field has the same value as is the default, the field is not serialized. It's not very convenient (true story).
2. The whitespace just consumes bytes. If you are debugging the JSON, all the tools are able to prettify the JSON for you.