### PR TITLE
Use `ExecutionContext` instead of `Executor` and refactoring towards …

### DIFF
--- a/core/src/test/scala/com/avast/grpc/jsonbridge/ReflectionGrpcJsonBridgeTest.scala
+++ b/core/src/test/scala/com/avast/grpc/jsonbridge/ReflectionGrpcJsonBridgeTest.scala
@@ -1,12 +1,12 @@
 package com.avast.grpc.jsonbridge
 
-import java.util.concurrent.{ExecutorService, Executors}
-
 import cats.effect.IO
 import com.avast.grpc.jsonbridge.GrpcJsonBridge.GrpcMethodName
 import io.grpc.Status
 import io.grpc.inprocess.InProcessServerBuilder
 import org.scalatest.{fixture, Matchers, Outcome}
+
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class ReflectionGrpcJsonBridgeTest extends fixture.FlatSpec with Matchers {
 
@@ -15,7 +15,6 @@ class ReflectionGrpcJsonBridgeTest extends fixture.FlatSpec with Matchers {
   override protected def withFixture(test: OneArgTest): Outcome = {
     val channelName = InProcessServerBuilder.generateName
     val server = InProcessServerBuilder.forName(channelName).addService(new TestServiceImpl()).build
-    implicit val executor: ExecutorService = Executors.newSingleThreadExecutor()
     val bridge = new ReflectionGrpcJsonBridge[IO](server)
     try {
       test(FixtureParam(bridge))

--- a/http4s/src/test/scala/com/avast/grpc/jsonbrige/http4s/Http4sTest.scala
+++ b/http4s/src/test/scala/com/avast/grpc/jsonbrige/http4s/Http4sTest.scala
@@ -1,7 +1,5 @@
 package com.avast.grpc.jsonbrige.http4s
 
-import java.util.concurrent.{Executor, Executors}
-
 import cats.data.NonEmptyList
 import cats.effect.IO
 import com.avast.grpc.jsonbridge._
@@ -10,11 +8,10 @@ import org.http4s.{Charset, Header, Headers, MediaType, Method, Request, Uri}
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.ScalaFutures
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Random
 
 class Http4sTest extends FunSuite with ScalaFutures {
-
-  implicit val executor: Executor = Executors.newSingleThreadExecutor()
 
   test("basic") {
     val service = Http4s(Configuration.Default)(new ReflectionGrpcJsonBridge[IO](TestServiceImpl.bindService()))


### PR DESCRIPTION
…`Resource`

/cc @augi @jendakol 
